### PR TITLE
Remove jQuery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "chance": "1.1.5",
-    "jquery": "3.5.1"
+    "chance": "1.1.5"
   },
   "devDependencies": {
     "web-ext": "4.2.0"

--- a/prepareDependencies.js
+++ b/prepareDependencies.js
@@ -13,5 +13,4 @@ function copyFile(filePath, destDir) {
     });
 }
 
-copyFile('node_modules/jquery/dist/jquery.min.js', jsDependenciesDir + 'jquery.min.js');
 copyFile('node_modules/chance/dist/chance.min.js', jsDependenciesDir  + 'chance.min.js');

--- a/src/js/dummy-augur.js
+++ b/src/js/dummy-augur.js
@@ -15,11 +15,11 @@ var DummyAugur = function() {
      * Considers: - min and max properties - name and label to guess input's
      * role, e.g. age, year
      */
-    this.defineInputPurpose = function($input) {
-        var purposeByLabel = this.defineInputPurpose($input);
+    this.defineInputPurpose = function(input) {
+        var purposeByLabel = this.defineInputPurpose(input);
 
         if (typeof purposeByLabel !== DummyPurposeEnum.UNDEFINED_PURPOSE) {
-            DummyLogger.log($input, 'purpose', purposeByLabel);
+            DummyLogger.log(input, 'purpose', purposeByLabel);
             return purposeByLabel;
         }
 
@@ -29,9 +29,9 @@ var DummyAugur = function() {
     /**
      * Considers label text: - phone - age - year
      */
-    this.defineInputPurpose = function($input) {
-        var stringRelatedToTheInput = this.getStringRelatedToTheInput($input);
-        DummyLogger.log($input, 'string related to the input', stringRelatedToTheInput);
+    this.defineInputPurpose = function(input) {
+        var stringRelatedToTheInput = this.getStringRelatedToTheInput(input);
+        DummyLogger.log(input, 'string related to the input', stringRelatedToTheInput);
 
         if (this.containsText(stringRelatedToTheInput, 'phone')) {
             return DummyPurposeEnum.PHONE_PURPOSE;
@@ -52,19 +52,22 @@ var DummyAugur = function() {
      *  - 'free' text before the input
      *  - id value
      *  - empty string ''
-     * @param $input
+     * @param input
      * @returns {*}
      */
-    this.getStringRelatedToTheInput = function($input) {
-        if ($input.prop('id')) {
-            var label = $('label[for="' + $input.prop('id') + '"]').text();
+    this.getStringRelatedToTheInput = function(input) {
+        if (input.id) {
+            var label = document.querySelector('label[for="' + input.id + '"]');
+            if (label) {
+                var labelText = label.textContent;
 
-            if(this.isNotEmpty(label)){
-                return label;
+                if(this.isNotEmpty(labelText)){
+                    return labelText;
+                }
             }
         }
 
-        var previousSibling = $input[0].previousSibling;
+        var previousSibling = input.previousSibling;
 
         if(previousSibling !== null) {
             var textBeforeInput = previousSibling.nodeValue;
@@ -73,14 +76,14 @@ var DummyAugur = function() {
             }
         }
 
-        if ($input.prop('id')) {
-            return $input.attr('id');
+        if (input.id) {
+            return input.getAttribute('id');
         }
         return '';
     };
 
     this.isNotEmpty = function(text) {
-        return $.trim(text);
+        return text.trim();
     };
 
     this.containsText = function(inString, text) {

--- a/src/js/dummy-engine.js
+++ b/src/js/dummy-engine.js
@@ -5,16 +5,16 @@ var DummyFormFiller = function () {
     var excludedNames = [];
 
     this.populateDummyData = function () {
-        var $here = $('html');
+        var here = document.documentElement;
         _augur = new DummyAugur();
         _generator = new DummyGenerator();
 
-        $here.find('form').each(function () {
-            $(this)[0].reset();
+        here.querySelectorAll('form').forEach(function (form) {
+            form.reset();
         });
 
-        $.each($here.find('input, select, textarea'), function () {
-            populateElementIfNotSetYet($(this), $here);
+        here.querySelectorAll('input, select, textarea').forEach(function (input) {
+            populateElementIfNotSetYet(input, here);
         });
         excludedNames = [];
     };
@@ -27,44 +27,44 @@ var DummyFormFiller = function () {
      * age, year. Ensures the value meets element's limitations, e.g. min,
      * minlength.
      */
-    function populateElementIfNotSetYet($element, $topParent) {
-        if (isInputText($element) && isEmptyVisibleAndEnabled($element)) {
-            populateWithRandomTextWisely($element);
-        } else if ($element.is('[type=email]') && isEmptyVisibleAndEnabled($element)) {
-            $element.val(_generator.getDummyEmail());
-        } else if ($element.is('[type=url]') && isEmptyVisibleAndEnabled($element)) {
-            $element.val('http://' + _generator.getDummyDomain());
-        } else if ($element.is('[type=radio]')) {
-            var groupName = $element.prop('name');
-            if (isEnabled($element) && !isExcluded(groupName)) {
-                var $radioInputs = findVisibleEnabledInputsByTypeAndName($topParent, 'radio', groupName);
-                if (!isAnyInputChecked($radioInputs)) {
-                    clickRandomInput($radioInputs);
+    function populateElementIfNotSetYet(element, topParent) {
+        if (isInputText(element) && isEmptyVisibleAndEnabled(element)) {
+            populateWithRandomTextWisely(element);
+        } else if (element.matches('[type=email]') && isEmptyVisibleAndEnabled(element)) {
+            element.value = _generator.getDummyEmail();
+        } else if (element.matches('[type=url]') && isEmptyVisibleAndEnabled(element)) {
+            element.value = 'http://' + _generator.getDummyDomain();
+        } else if (element.matches('[type=radio]')) {
+            var groupName = element.name;
+            if (isEnabled(element) && !isExcluded(groupName)) {
+                var radioInputs = findVisibleEnabledInputsByTypeAndName(topParent, 'radio', groupName);
+                if (!isAnyInputChecked(radioInputs)) {
+                    clickRandomInput(radioInputs);
                 }
                 excludedNames.push(groupName);
             }
-        } else if ($element.is('[type=checkbox]')) {
-            var groupName = $element.prop('name');
-            if (isVisible($element) && isEnabled($element) && !isExcluded(groupName)) {
-                var $checkboxInputs = findVisibleEnabledInputsByTypeAndName($topParent, 'checkbox', groupName);
-                if (!isAnyInputChecked($checkboxInputs)) {
-                    clickRandomInputs($checkboxInputs);
+        } else if (element.matches('[type=checkbox]')) {
+            var groupName = element.name;
+            if (isVisible(element) && isEnabled(element) && !isExcluded(groupName)) {
+                var checkboxInputs = findVisibleEnabledInputsByTypeAndName(topParent, 'checkbox', groupName);
+                if (!isAnyInputChecked(checkboxInputs)) {
+                    clickRandomInputs(checkboxInputs);
                 }
                 excludedNames.push(groupName);
             }
-        } else if ($element.is('[type=password]') && isEmptyVisibleAndEnabled($element)) {
-            _generator.withDummyPassword($element);
-        } else if ($element.is('select') && isSelectVisibleEnabledAndUnselected($element)) {
-            clickRandomOptionOrOptions($element);
-        } else if ($element.is('[type=number]') && isEmptyVisibleAndEnabled($element)) {
-            populateWithRandomNumberWisely($element);
-        } else if ($element.is('[type=date]') && isEmptyVisibleAndEnabled($element)) {
-            populateWithRandomDateWisely($element);
-        } else if ($element.is('[type=tel]') && isEmptyVisibleAndEnabled($element)) {
-            $element.val(_generator.getDummyPhone());
-        } else if ($element.is('textarea') && isEmptyVisibleAndEnabled($element)) {
-            let limits = DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits($element);
-            $element.val(_generator.getDummyParagraph(limits));
+        } else if (element.matches('[type=password]') && isEmptyVisibleAndEnabled(element)) {
+            _generator.withDummyPassword(element);
+        } else if (element.matches('select') && isSelectVisibleEnabledAndUnselected(element)) {
+            clickRandomOptionOrOptions(element);
+        } else if (element.matches('[type=number]') && isEmptyVisibleAndEnabled(element)) {
+            populateWithRandomNumberWisely(element);
+        } else if (element.matches('[type=date]') && isEmptyVisibleAndEnabled(element)) {
+            populateWithRandomDateWisely(element);
+        } else if (element.matches('[type=tel]') && isEmptyVisibleAndEnabled(element)) {
+            element.value = _generator.getDummyPhone();
+        } else if (element.matches('textarea') && isEmptyVisibleAndEnabled(element)) {
+            let limits = DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits(element);
+            element.value = _generator.getDummyParagraph(limits);
         } else {
             return;
         }
@@ -76,17 +76,17 @@ var DummyFormFiller = function () {
             "bubbles": true,
             "cancelable": true
         });
-        $element[0].dispatchEvent(event);
+        element.dispatchEvent(event);
     }
 
-    function clickRandomInput($elements) {
-        $(chance.pick($elements)).click();
+    function clickRandomInput(elements) {
+        chance.pick(elements).click();
     }
 
-    function clickRandomInputs($elements) {
-        $.each($elements, function () {
-            if (chance.bool() && isVisible($(this)) && isEnabled($(this))) {
-                $($(this)).click();
+    function clickRandomInputs(elements) {
+        elements.forEach(function (element) {
+            if (chance.bool() && isVisible(element) && isEnabled(element)) {
+                element.click();
             }
         });
     }
@@ -96,16 +96,16 @@ var DummyFormFiller = function () {
      * select single option if currently selected is rightfully selected. Does not
      * select multiple options if any already selected.
      */
-    function clickRandomOptionOrOptions($select) {
-        if ($select.prop('multiple')) {
-            $select.find('option').each(function () {
-                $(this).prop("selected", chance.bool());
+    function clickRandomOptionOrOptions(select) {
+        if (select.multiple) {
+            select.querySelectorAll('option').forEach(function (option) {
+                option.selected = chance.bool();
             });
         } else {
-            var rightfulOptions = getRightfulOptions($select);
+            var rightfulOptions = getRightfulOptions(select);
 
             if (rightfulOptions.length > 0) {
-                $(chance.pick(rightfulOptions)).prop("selected", true);
+                chance.pick(rightfulOptions).selected = true;
             }
         }
     }
@@ -116,14 +116,14 @@ var DummyFormFiller = function () {
      * - enabled
      * - not empty
      */
-    function getRightfulOptions($select) {
+    function getRightfulOptions(select) {
         var rightfulOptions = [];
         var notRightfulTextsForSelect = ['select', 'choose', 'pick', ' wybierz'];
 
-        $select.find('option').each(function () {
-            var selectText = $(this).text();
-            if (!isEmpty($(this)) && isEnabled($(this)) && $.trim(selectText) && !_augur.containsTexts(selectText, notRightfulTextsForSelect)) {
-                rightfulOptions.push($(this));
+        select.querySelectorAll('option').forEach(function (option) {
+            var selectText = option.textContent;
+            if (!isEmpty(option) && isEnabled(option) && selectText.trim() && !_augur.containsTexts(selectText, notRightfulTextsForSelect)) {
+                rightfulOptions.push(option);
             }
         });
 
@@ -136,22 +136,22 @@ var DummyFormFiller = function () {
      *   - min and max properties
      *   - name and label to guess input's role, e.g. age, year
      */
-    function populateWithRandomTextWisely($element) {
-        var purpose = _augur.defineInputPurpose($element);
+    function populateWithRandomTextWisely(element) {
+        var purpose = _augur.defineInputPurpose(element);
 
         switch (purpose) {
             case DummyPurposeEnum.PHONE_PURPOSE:
             case DummyPurposeEnum.AGE_PURPOSE:
             case DummyPurposeEnum.YEAR_PURPOSE:
-                populateWithRandomNumberWisely($element, purpose);
+                populateWithRandomNumberWisely(element, purpose);
                 break;
             case DummyPurposeEnum.EMAIL_PURPOSE:
-                $element.val(_generator.getDummyEmail());
+                element.value = _generator.getDummyEmail();
                 break;
             case DummyPurposeEnum.UNDEFINED_PURPOSE:
             default:
-                var limits = DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits($element);
-                $element.val(_generator.getDummyText(limits));
+                var limits = DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits(element);
+                element.value = _generator.getDummyText(limits);
         }
     }
 
@@ -160,25 +160,25 @@ var DummyFormFiller = function () {
      *   - min and max properties
      *   - name and label to guess input's role, e.g. age, year
      */
-    function populateWithRandomNumberWisely($element, purpose) {
-        purpose = (typeof purpose !== 'undefined') ? purpose : _augur.defineInputPurpose($element);
+    function populateWithRandomNumberWisely(element, purpose) {
+        purpose = (typeof purpose !== 'undefined') ? purpose : _augur.defineInputPurpose(element);
 
         switch (purpose) {
             case DummyPurposeEnum.PHONE_PURPOSE:
-                $element.val(_generator.getDummyPhone());
+                element.value = _generator.getDummyPhone();
                 break;
             case DummyPurposeEnum.AGE_PURPOSE:
-                var ageLimits = DummyLimitsUtils.readAndAdjustMinMaxLimits(DummyPurposeEnum.AGE_PURPOSE, $element);
-                $element.val(_generator.getDummyNumber(ageLimits));
+                var ageLimits = DummyLimitsUtils.readAndAdjustMinMaxLimits(DummyPurposeEnum.AGE_PURPOSE, element);
+                element.value = _generator.getDummyNumber(ageLimits);
                 break;
             case DummyPurposeEnum.YEAR_PURPOSE:
-                var yearLimits = DummyLimitsUtils.readAndAdjustMinMaxLimits(DummyPurposeEnum.YEAR_PURPOSE, $element);
-                $element.val(_generator.getDummyNumber(yearLimits));
+                var yearLimits = DummyLimitsUtils.readAndAdjustMinMaxLimits(DummyPurposeEnum.YEAR_PURPOSE, element);
+                element.value = _generator.getDummyNumber(yearLimits);
                 break;
             case DummyPurposeEnum.UNDEFINED_PURPOSE:
             default:
-                var limits = DummyLimitsUtils.readAndAdjustMinMaxLimits(null, $element);
-                $element.val(_generator.getDummyNumber(limits));
+                var limits = DummyLimitsUtils.readAndAdjustMinMaxLimits(null, element);
+                element.value = _generator.getDummyNumber(limits);
         }
     }
 
@@ -186,30 +186,30 @@ var DummyFormFiller = function () {
      * Populates given element with a random date. Considers:
      *   - min and max properties
      */
-    function populateWithRandomDateWisely($element) {
-        var limits = DummyLimitsUtils.readAndAdjustDateLimits($element);
+    function populateWithRandomDateWisely(element) {
+        var limits = DummyLimitsUtils.readAndAdjustDateLimits(element);
 
-        $element.val(_generator.getDummyDate(limits));
+        element.value = _generator.getDummyDate(limits);
     }
 
-    function isInputText($element) {
-        return $element.is('[type=text]')
-            || ($element.is('input') && !$element.is('[type]')); //or no input type is set, so it's the 'text' by default
+    function isInputText(element) {
+        return element.matches('[type=text]')
+            || (element.matches('input') && !element.matches('[type]')); //or no input type is set, so it's the 'text' by default
     }
 
-    function isEmptyVisibleAndEnabled($element) {
-        return isEmpty($element) && isVisible($element) && isEnabled($element);
+    function isEmptyVisibleAndEnabled(element) {
+        return isEmpty(element) && isVisible(element) && isEnabled(element);
     }
 
-    function isSelectVisibleEnabledAndUnselected($select) {
-        return isVisible($select) && isEnabled($select) && !isAnyRightfulOptionSelected($select);
+    function isSelectVisibleEnabledAndUnselected(select) {
+        return isVisible(select) && isEnabled(select) && !isAnyRightfulOptionSelected(select);
     }
 
-    function isAnyRightfulOptionSelected($select) {
-        var rightfulOptions = getRightfulOptions($select);
+    function isAnyRightfulOptionSelected(select) {
+        var rightfulOptions = getRightfulOptions(select);
 
         for (var i = 0; i < rightfulOptions.length; ++i) {
-            if ($(rightfulOptions[i]).prop('selected')) {
+            if (rightfulOptions[i].selected) {
                 return true;
             }
         }
@@ -217,22 +217,26 @@ var DummyFormFiller = function () {
         return false;
     }
 
-    function isEmpty($element) {
-        return !$.trim($element.val());
+    function isEmpty(element) {
+        return !element.value.trim();
     }
 
-    function isVisible($element) {
-        return $element.is(":visible");
+    /**
+     * Taken from jQuery.
+     * https://github.com/jquery/jquery/blob/main/src/css/hiddenVisibleSelectors.js
+     */
+    function isVisible(element) {
+        return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
     }
 
-    function isEnabled($element) {
-        return $element.is(":enabled");
+    function isEnabled(element) {
+        return element.matches(":enabled");
     }
 
-    function isAnyInputChecked($elements) {
+    function isAnyInputChecked(elements) {
         var anyInputChecked = false;
-        $elements.each(function () {
-            if ($(this).is(':checked')) {
+        elements.forEach(function (element) {
+            if (element.matches(':checked')) {
                 anyInputChecked = true;
                 return false; // breaks the loop only; does not return anything from the method
             }
@@ -241,12 +245,12 @@ var DummyFormFiller = function () {
         return anyInputChecked;
     }
 
-    function findVisibleEnabledInputsByTypeAndName($here, type, name) {
-        return $here.find('input[type=' + type + '][name="' + name + '"]:visible:enabled');
+    function findVisibleEnabledInputsByTypeAndName(here, type, name) {
+        return Array.from(here.querySelectorAll('input[type=' + type + '][name="' + name + '"]:enabled')).filter(isVisible);
     }
 
     function isExcluded(groupName) {
-        return $.inArray(groupName, excludedNames) !== -1;
+        return excludedNames.includes(groupName);
     }
 
     return this;

--- a/src/js/dummy-generator.js
+++ b/src/js/dummy-generator.js
@@ -30,13 +30,13 @@ var DummyGenerator = function () {
         }
 
         try {
-            var text = $.trim(chance.string({
+            var text = chance.string({
                 length: chance.natural({
                     min: limits.minlength,
                     max: limits.maxlength
                 }),
                 pool: DEI_KOBOL
-            }));
+            }).trim();
 
             return chance.capitalize(text);
         }
@@ -62,13 +62,13 @@ var DummyGenerator = function () {
         return chance.domain();
     };
 
-    this.withDummyPassword = function ($element) {
-        this.populateWith($element, CUSTOM_DUMMY_PASSWORD_KEY);
+    this.withDummyPassword = function (element) {
+        this.populateWith(element, CUSTOM_DUMMY_PASSWORD_KEY);
     };
 
-    this.populateWith = function ($element, optionName) {
+    this.populateWith = function (element, optionName) {
         chrome.storage.local.get(DEFAULT_OPTIONS, function (options) {
-            $element.val(options[optionName]);
+            element.value = options[optionName];
         });
     };
 

--- a/src/js/dummy-limits.js
+++ b/src/js/dummy-limits.js
@@ -1,5 +1,5 @@
 //TODO PT: DRY; also simplify, e.g. rather than limit range return the random value from the range
-function DummyLimits($element) {
+function DummyLimits(element) {
     this.minlength = null;
     this.maxlength = null;
     this.min = null;
@@ -9,17 +9,17 @@ function DummyLimits($element) {
         return value == null ? null : new Number(value);
     }
 
-    if(typeof $element !== 'undefined'){
-        this.minlength = this.toNumberOrNull($element.attr('minlength'));
-        this.maxlength = this.toNumberOrNull($element.attr('maxlength'));
-        this.min = this.toNumberOrNull($element.attr('min'));
-        this.max = this.toNumberOrNull($element.attr('max'));
+    if(typeof element !== 'undefined'){
+        this.minlength = this.toNumberOrNull(element.getAttribute('minlength'));
+        this.maxlength = this.toNumberOrNull(element.getAttribute('maxlength'));
+        this.min = this.toNumberOrNull(element.getAttribute('min'));
+        this.max = this.toNumberOrNull(element.getAttribute('max'));
 
-        DummyLogger.log($element, 'read limits', this);
+        DummyLogger.log(element, 'read limits', this);
     }
 }
 
-function DummyDateLimits($element) {
+function DummyDateLimits(element) {
     this.min = null;
     this.max = null;
 
@@ -27,9 +27,9 @@ function DummyDateLimits($element) {
         return value == null ? null : new Date(value);
     }
 
-    if(typeof $element !== 'undefined'){
-        this.min = this.toDateOrNull($element.attr('min'));
-        this.max = this.toDateOrNull($element.attr('max'));
+    if(typeof element !== 'undefined'){
+        this.min = this.toDateOrNull(element.getAttribute('min'));
+        this.max = this.toDateOrNull(element.getAttribute('max'));
     }
 }
 
@@ -40,9 +40,9 @@ var DummyLimitsUtils = {}
  * Then if the limits contain min and max values they are
  * returned. Otherwise new values are created.
  */
-DummyLimitsUtils.readAndAdjustDateLimits = function($element){
-    var limits = new DummyDateLimits($element);
-    DummyLogger.log($element, 'read limits', this);
+DummyLimitsUtils.readAndAdjustDateLimits = function(element){
+    var limits = new DummyDateLimits(element);
+    DummyLogger.log(element, 'read limits', this);
 
     if (limits.min != null && limits.max != null) {
         return limits;
@@ -61,7 +61,7 @@ DummyLimitsUtils.readAndAdjustDateLimits = function($element){
         limits.max = new Date('2015');
     }
 
-    DummyLogger.log($element, 'adjusted limits', limits);
+    DummyLogger.log(element, 'adjusted limits', limits);
 
     return limits;
 }
@@ -71,9 +71,9 @@ DummyLimitsUtils.readAndAdjustDateLimits = function($element){
  * Then if the limits contain min and max values they are
  * returned. Otherwise new values are created for provided purpose.
  */
-DummyLimitsUtils.readAndAdjustMinMaxLimits = function(purpose, $element){
-    var limits = new DummyLimits($element);
-    DummyLogger.log($element, 'read limits', this);
+DummyLimitsUtils.readAndAdjustMinMaxLimits = function(purpose, element){
+    var limits = new DummyLimits(element);
+    DummyLogger.log(element, 'read limits', this);
 
 
     if (limits.min != null && limits.max != null) {
@@ -101,7 +101,7 @@ DummyLimitsUtils.readAndAdjustMinMaxLimits = function(purpose, $element){
         }
     }
 
-    DummyLogger.log($element, 'adjusted limits', limits);
+    DummyLogger.log(element, 'adjusted limits', limits);
 
     return limits;
 }
@@ -111,9 +111,9 @@ DummyLimitsUtils.readAndAdjustMinMaxLimits = function(purpose, $element){
  * Then if the limits contain min and max values they are
  * returned. Otherwise new values are created.
  */
-DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits = function($element){
-    let limits = new DummyLimits($element);
-    DummyLogger.log($element, 'read limits', this);
+DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits = function(element){
+    let limits = new DummyLimits(element);
+    DummyLogger.log(element, 'read limits', this);
 
     //adjusting
     if (limits.minlength != null && limits.maxlength != null) {
@@ -129,7 +129,7 @@ DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits = function($element){
             max : limits.minlength + 5
             }));
     } else {
-        if ($element.is('textarea')) {
+        if (element.matches('textarea')) {
             limits.minlength = 100;
             limits.maxlength = 500;
         } else {
@@ -138,7 +138,7 @@ DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits = function($element){
         }
     }
 
-    DummyLogger.log($element, 'adjusted limits', limits);
+    DummyLogger.log(element, 'adjusted limits', limits);
 
     return limits;
 };

--- a/src/js/dummy-logger.js
+++ b/src/js/dummy-logger.js
@@ -4,13 +4,13 @@ var DummyLogger = {}
  * Prints information next to the given element. Doesn't log if there's
  * nothing to show.
  */
-DummyLogger.log = function ($element, infoText, value) {
+DummyLogger.log = function (element, infoText, value) {
     function logIt() {
         if ((value && typeof value !== 'object') || (typeof value === 'object' && Object.keys(value).length !== 0)) {
             console.log('('
-                + 'id=\'' + $element.prop('id') + '\''
-                + ', name=\'' + $element.prop('name') + '\''
-                + ', type=\'' + $element.prop('type') + '\''
+                + 'id=\'' + element.id + '\''
+                + ', name=\'' + element.name + '\''
+                + ', type=\'' + element.type + '\''
                 + '): '
                 + infoText + ':\n'
                 + JSON.stringify(value, null, 4));

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,7 +41,6 @@
       ],
       "js": [
         "options/options_defaults.js",
-        "js-ext/jquery.min.js",
         "js-ext/chance.min.js",
         "js/dummy-logger.js",
         "js/dummy-augur.js",


### PR DESCRIPTION
These days, JavaScript supports most of the features natively. So this will make the extension lighter.

The exception is the :visible selector, which had to be copied from jQuery.

This is mostly one-to-one conversion, there is still space for modernizing the code and making it more idiomatic (e.g. replacing loops with functional constructs).

