### PR TITLE
Add support for pattern attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "chance": "^1.1.8"
+        "chance": "^1.1.8",
+        "reregexp": "^1.6.0"
       },
       "devDependencies": {
         "web-ext": "^7.4.0"
@@ -4302,6 +4303,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reregexp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/reregexp/-/reregexp-1.6.0.tgz",
+      "integrity": "sha512-LDRDxAd5mYCT3ikkMs+WzMMIh86qVpZFbD4L+y4aPKXnE8K5PU3bykPdm/z8gq3WgsVm+1oiQlrSpYMZz9Ra9A=="
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
@@ -8648,6 +8654,11 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
+    },
+    "reregexp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/reregexp/-/reregexp-1.6.0.tgz",
+      "integrity": "sha512-LDRDxAd5mYCT3ikkMs+WzMMIh86qVpZFbD4L+y4aPKXnE8K5PU3bykPdm/z8gq3WgsVm+1oiQlrSpYMZz9Ra9A=="
     },
     "resolve-alpn": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "node": ">=19.6.0"
   },
   "dependencies": {
-    "chance": "^1.1.8"
+    "chance": "^1.1.8",
+    "reregexp": "^1.6.0"
   },
   "devDependencies": {
     "web-ext": "^7.4.0"

--- a/prepareDependencies.js
+++ b/prepareDependencies.js
@@ -13,4 +13,16 @@ function copyFile(filePath, destDir) {
     });
 }
 
+function copyAndTransformFile(filePath, destPath, transformer) {
+    const data = fs.readFileSync(filePath, 'utf-8');
+    fs.writeFileSync(destPath, transformer(data), 'utf-8');
+}
+
 copyFile('node_modules/chance/dist/chance.min.js', jsDependenciesDir  + 'chance.min.js');
+copyAndTransformFile(
+    'node_modules/reregexp/lib/index.js',
+    jsDependenciesDir + 'reregexp.js',
+    // Our CommonJS emulation hack only makes `exports` available temporarily
+    // so we need to change references to it to variables in real scope.
+    data => data.replaceAll(/^exports\.((?!default)\w+)\b(\s*)=((?!\s*\1|.+void 0).+)$/mg, 'var $1$2=$3\nexports\.$1 = $1;').replaceAll(/exports.(\w+)\b(?!\s*=)/g, '$1')
+);

--- a/show.html
+++ b/show.html
@@ -16,6 +16,9 @@
         Text input (min 10 characters):
         <input id="text32" type="text" minlength="10">
         <br>
+        Text input (pattern):
+        <input id="text33" type="text" pattern="[0-9]+">
+        <br>
         Email input:
         <input id="email" type="email">
         <br>

--- a/src/background.js
+++ b/src/background.js
@@ -1,3 +1,7 @@
 chrome.browserAction.onClicked.addListener(() => {
-    chrome.tabs.executeScript({file: "js/main.js"});
+    const contentScriptPath = JSON.stringify(chrome.extension.getURL('js/main.js'));
+    chrome.tabs.executeScript({
+        // Cannot use `file` since that does not support ES modules.
+        code: `import(${contentScriptPath}).then(({ run }) => run());`
+    });
 });

--- a/src/js/dummy-augur.js
+++ b/src/js/dummy-augur.js
@@ -1,4 +1,6 @@
-var DummyPurposeEnum = {
+import { DummyLogger } from './dummy-logger.js';
+
+export const DummyPurposeEnum = {
     /** Input purposes */
     PHONE_PURPOSE: 'phone_purpose',
     AGE_PURPOSE: 'age_purpose',
@@ -9,7 +11,7 @@ var DummyPurposeEnum = {
     UNDEFINED_PURPOSE: 'undefined_purpose'
 };
 
-var DummyAugur = function() {
+export function DummyAugur() {
 
     /**
      * Considers: - min and max properties - name and label to guess input's

--- a/src/js/dummy-engine.js
+++ b/src/js/dummy-engine.js
@@ -137,10 +137,17 @@ export const DummyFormFiller = function () {
     /**
      * Populates given element with a random text or readdresses the task to more
      * appropriate populator. Considers:
+     *   - pattern property
      *   - min and max properties
      *   - name and label to guess input's role, e.g. age, year
      */
     function populateWithRandomTextWisely(element) {
+        if (element.pattern) {
+            element.value = _generator.getDummyTextMatchingPattern(element.pattern);
+            // TODO: reregexp does not support {min,max,}length attributes
+            return;
+        }
+
         var purpose = _augur.defineInputPurpose(element);
 
         switch (purpose) {

--- a/src/js/dummy-engine.js
+++ b/src/js/dummy-engine.js
@@ -1,4 +1,8 @@
-var DummyFormFiller = function () {
+import { DummyAugur, DummyPurposeEnum } from './dummy-augur.js';
+import { readAndAdjustMinLengthMaxLengthLimits, readAndAdjustMinMaxLimits, readAndAdjustDateLimits } from './dummy-limits.js';
+import { DummyGenerator } from './dummy-generator.js';
+
+export const DummyFormFiller = function () {
 
     var _augur;
     var _generator;
@@ -63,7 +67,7 @@ var DummyFormFiller = function () {
         } else if (element.matches('[type=tel]') && isEmptyVisibleAndEnabled(element)) {
             element.value = _generator.getDummyPhone();
         } else if (element.matches('textarea') && isEmptyVisibleAndEnabled(element)) {
-            let limits = DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits(element);
+            let limits = readAndAdjustMinLengthMaxLengthLimits(element);
             element.value = _generator.getDummyParagraph(limits);
         } else {
             return;
@@ -80,12 +84,12 @@ var DummyFormFiller = function () {
     }
 
     function clickRandomInput(elements) {
-        chance.pick(elements).click();
+        _generator.chance.pick(elements).click();
     }
 
     function clickRandomInputs(elements) {
         elements.forEach(function (element) {
-            if (chance.bool() && isVisible(element) && isEnabled(element)) {
+            if (_generator.chance.bool() && isVisible(element) && isEnabled(element)) {
                 element.click();
             }
         });
@@ -99,13 +103,13 @@ var DummyFormFiller = function () {
     function clickRandomOptionOrOptions(select) {
         if (select.multiple) {
             select.querySelectorAll('option').forEach(function (option) {
-                option.selected = chance.bool();
+                option.selected = _generator.chance.bool();
             });
         } else {
             var rightfulOptions = getRightfulOptions(select);
 
             if (rightfulOptions.length > 0) {
-                chance.pick(rightfulOptions).selected = true;
+                _generator.chance.pick(rightfulOptions).selected = true;
             }
         }
     }
@@ -150,7 +154,7 @@ var DummyFormFiller = function () {
                 break;
             case DummyPurposeEnum.UNDEFINED_PURPOSE:
             default:
-                var limits = DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits(element);
+                var limits = readAndAdjustMinLengthMaxLengthLimits(element);
                 element.value = _generator.getDummyText(limits);
         }
     }
@@ -168,16 +172,16 @@ var DummyFormFiller = function () {
                 element.value = _generator.getDummyPhone();
                 break;
             case DummyPurposeEnum.AGE_PURPOSE:
-                var ageLimits = DummyLimitsUtils.readAndAdjustMinMaxLimits(DummyPurposeEnum.AGE_PURPOSE, element);
+                var ageLimits = readAndAdjustMinMaxLimits(DummyPurposeEnum.AGE_PURPOSE, element);
                 element.value = _generator.getDummyNumber(ageLimits);
                 break;
             case DummyPurposeEnum.YEAR_PURPOSE:
-                var yearLimits = DummyLimitsUtils.readAndAdjustMinMaxLimits(DummyPurposeEnum.YEAR_PURPOSE, element);
+                var yearLimits = readAndAdjustMinMaxLimits(DummyPurposeEnum.YEAR_PURPOSE, element);
                 element.value = _generator.getDummyNumber(yearLimits);
                 break;
             case DummyPurposeEnum.UNDEFINED_PURPOSE:
             default:
-                var limits = DummyLimitsUtils.readAndAdjustMinMaxLimits(null, element);
+                var limits = readAndAdjustMinMaxLimits(null, element);
                 element.value = _generator.getDummyNumber(limits);
         }
     }
@@ -187,7 +191,7 @@ var DummyFormFiller = function () {
      *   - min and max properties
      */
     function populateWithRandomDateWisely(element) {
-        var limits = DummyLimitsUtils.readAndAdjustDateLimits(element);
+        var limits = readAndAdjustDateLimits(element);
 
         element.value = _generator.getDummyDate(limits);
     }
@@ -254,4 +258,4 @@ var DummyFormFiller = function () {
     }
 
     return this;
-}();
+};

--- a/src/js/dummy-generator.js
+++ b/src/js/dummy-generator.js
@@ -8,6 +8,7 @@ async function require(modulePath) {
     return exports;
 }
 const { Chance } = await require('../js-ext/chance.min.js');
+const { default: ReRegExp } = await require('../js-ext/reregexp.js');
 
 import { DummyLogger } from './dummy-logger.js';
 import { DEFAULT_OPTIONS, CUSTOM_DUMMY_PASSWORD_KEY } from '../options/options_defaults.js';
@@ -55,6 +56,19 @@ export function DummyGenerator() {
             }).trim();
 
             return this.chance.capitalize(text);
+        }
+        catch (err) {
+            DummyLogger.log(err);
+        }
+    };
+
+    /**
+     * Returns random text matching given regexp pattern.
+     */
+    this.getDummyTextMatchingPattern = function (pattern) {
+        try {
+            const reregexp = new ReRegExp(pattern);
+            return reregexp.build();
         }
         catch (err) {
             DummyLogger.log(err);

--- a/src/js/dummy-generator.js
+++ b/src/js/dummy-generator.js
@@ -1,9 +1,25 @@
-var DummyGenerator = function () {
+// Does not support ES modules.
+async function require(modulePath) {
+    const oldExports = window.exports;
+    window.exports = { };
+    await import(modulePath);
+    const exports = window.exports;
+    window.exports = oldExports;
+    return exports;
+}
+const { Chance } = await require('../js-ext/chance.min.js');
+
+import { DummyLogger } from './dummy-logger.js';
+import { DEFAULT_OPTIONS, CUSTOM_DUMMY_PASSWORD_KEY } from '../options/options_defaults.js';
+
+export function DummyGenerator() {
+    this.chance = new Chance();
+
     var DEI_KOBOL = 'Dei Kobol una apita uthoukarana ' + 'Ukthea mavatha gaman kerimuta '
         + 'Obe satharane mua osavathamanabanta ' + 'Api obata yagnya karama'
         + 'phnglui mglwnafh Cthulhu R\'lyeh wgah\'nagl fhtagn';
 
-    var DUMMY_EMAIL = chance.email();
+    var DUMMY_EMAIL = this.chance.email();
 
     /**
      * Returns random number that meets given limitations, i.e. min and max
@@ -11,7 +27,7 @@ var DummyGenerator = function () {
      */
     this.getDummyNumber = function (limits) {
         try {
-            return chance.natural({
+            return this.chance.natural({
                 min: limits.min,
                 max: limits.max
             });
@@ -30,15 +46,15 @@ var DummyGenerator = function () {
         }
 
         try {
-            var text = chance.string({
-                length: chance.natural({
+            var text = this.chance.string({
+                length: this.chance.natural({
                     min: limits.minlength,
                     max: limits.maxlength
                 }),
                 pool: DEI_KOBOL
             }).trim();
 
-            return chance.capitalize(text);
+            return this.chance.capitalize(text);
         }
         catch (err) {
             DummyLogger.log(err);
@@ -49,7 +65,7 @@ var DummyGenerator = function () {
      * Returns random phone number.
      */
     this.getDummyPhone = function (limits) {
-        return chance.phone({
+        return this.chance.phone({
             formatted: false
         });
     };
@@ -59,7 +75,7 @@ var DummyGenerator = function () {
     };
 
     this.getDummyDomain = function () {
-        return chance.domain();
+        return this.chance.domain();
     };
 
     this.withDummyPassword = function (element) {
@@ -74,7 +90,7 @@ var DummyGenerator = function () {
 
     this.getDummyDate = function (limits) {
         try {
-            return chance.date({
+            return this.chance.date({
                 min: limits.min,
                 max: limits.max
             }).toISOString().split('T')[0];
@@ -85,7 +101,7 @@ var DummyGenerator = function () {
     };
 
     this.getDummyParagraph = function (limits) {
-        let length = chance.natural({
+        let length = this.chance.natural({
             min: limits.minlength,
             max: limits.maxlength
         });
@@ -93,7 +109,7 @@ var DummyGenerator = function () {
         let paragraph = '';
 
         while (paragraph.length < length) {
-            paragraph += chance.sentence() + ' ';
+            paragraph += this.chance.sentence() + ' ';
         }
         return paragraph.substring(0, length);
     };

--- a/src/js/dummy-limits.js
+++ b/src/js/dummy-limits.js
@@ -1,3 +1,6 @@
+import { DummyLogger } from './dummy-logger.js';
+import { DummyPurposeEnum } from './dummy-augur.js';
+
 //TODO PT: DRY; also simplify, e.g. rather than limit range return the random value from the range
 function DummyLimits(element) {
     this.minlength = null;
@@ -33,14 +36,12 @@ function DummyDateLimits(element) {
     }
 }
 
-var DummyLimitsUtils = {}
-
 /**
  * Reads min and max limits from a date input.
  * Then if the limits contain min and max values they are
  * returned. Otherwise new values are created.
  */
-DummyLimitsUtils.readAndAdjustDateLimits = function(element){
+export function readAndAdjustDateLimits(element){
     var limits = new DummyDateLimits(element);
     DummyLogger.log(element, 'read limits', this);
 
@@ -71,7 +72,7 @@ DummyLimitsUtils.readAndAdjustDateLimits = function(element){
  * Then if the limits contain min and max values they are
  * returned. Otherwise new values are created for provided purpose.
  */
-DummyLimitsUtils.readAndAdjustMinMaxLimits = function(purpose, element){
+export function readAndAdjustMinMaxLimits(purpose, element){
     var limits = new DummyLimits(element);
     DummyLogger.log(element, 'read limits', this);
 
@@ -111,7 +112,7 @@ DummyLimitsUtils.readAndAdjustMinMaxLimits = function(purpose, element){
  * Then if the limits contain min and max values they are
  * returned. Otherwise new values are created.
  */
-DummyLimitsUtils.readAndAdjustMinLengthMaxLengthLimits = function(element){
+export function readAndAdjustMinLengthMaxLengthLimits(element){
     let limits = new DummyLimits(element);
     DummyLogger.log(element, 'read limits', this);
 

--- a/src/js/dummy-logger.js
+++ b/src/js/dummy-logger.js
@@ -1,25 +1,27 @@
-var DummyLogger = {}
+import { DEFAULT_OPTIONS, LOGGING_ENABLED_KEY } from '../options/options_defaults.js';
 
-/**
- * Prints information next to the given element. Doesn't log if there's
- * nothing to show.
- */
-DummyLogger.log = function (element, infoText, value) {
-    function logIt() {
-        if ((value && typeof value !== 'object') || (typeof value === 'object' && Object.keys(value).length !== 0)) {
-            console.log('('
-                + 'id=\'' + element.id + '\''
-                + ', name=\'' + element.name + '\''
-                + ', type=\'' + element.type + '\''
-                + '): '
-                + infoText + ':\n'
-                + JSON.stringify(value, null, 4));
+export class DummyLogger {
+    /**
+     * Prints information next to the given element. Doesn't log if there's
+     * nothing to show.
+     */
+    static log(element, infoText, value) {
+        function logIt() {
+            if ((value && typeof value !== 'object') || (typeof value === 'object' && Object.keys(value).length !== 0)) {
+                console.log('('
+                    + 'id=\'' + element.id + '\''
+                    + ', name=\'' + element.name + '\''
+                    + ', type=\'' + element.type + '\''
+                    + '): '
+                    + infoText + ':\n'
+                    + JSON.stringify(value, null, 4));
+            }
         }
+
+        chrome.storage.local.get(LOGGING_ENABLED_KEY, function(options){
+            if(options[LOGGING_ENABLED_KEY]) {
+                logIt();
+            }
+        });
     }
-
-    chrome.storage.local.get(LOGGING_ENABLED_KEY, function(options){
-        if(options[LOGGING_ENABLED_KEY]) {
-            logIt();
-        }
-    });
-};
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,7 +1,12 @@
-try {
-    console.log('Run Dummy Form Filler');
-    DummyFormFiller.populateDummyData();
-} catch (e) {
-    console.error('Cannot run Dummy Form Filler - raise an issue on https://github.com/ptomaszek/dummy-form-filler/issues');
-    console.error(e);
+import { DummyFormFiller } from './dummy-engine.js';
+
+export function run() {
+    try {
+        console.log('Run Dummy Form Filler');
+        const filler = new DummyFormFiller();
+        filler.populateDummyData();
+    } catch (e) {
+        console.error('Cannot run Dummy Form Filler - raise an issue on https://github.com/ptomaszek/dummy-form-filler/issues');
+        console.error(e);
+    }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,28 +27,20 @@
   },
   "background": {
     "scripts": [
-      "options/options_defaults.js", "background.js"
+      "background.js"
     ],
     "persistent": false
   },
 
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "exclude_matches": [
-        "*://*/*.xml",
-        "file:///*/*.xml"
-      ],
-      "js": [
-        "options/options_defaults.js",
-        "js-ext/chance.min.js",
-        "js/dummy-logger.js",
-        "js/dummy-augur.js",
-        "js/dummy-limits.js",
-        "js/dummy-generator.js",
-        "js/dummy-engine.js"
-      ]
-    }
+  "web_accessible_resources": [
+    "js-ext/chance.min.js",
+    "js/dummy-augur.js",
+    "js/dummy-engine.js",
+    "js/dummy-generator.js",
+    "js/dummy-limits.js",
+    "js/dummy-logger.js",
+    "js/main.js",
+    "options/options_defaults.js"
   ],
 
   "options_ui": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,6 +34,7 @@
 
   "web_accessible_resources": [
     "js-ext/chance.min.js",
+    "js-ext/reregexp.js",
     "js/dummy-augur.js",
     "js/dummy-engine.js",
     "js/dummy-generator.js",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -28,8 +28,7 @@
     </fieldset>
 </div>
 
-<script src="options_defaults.js"></script>
-<script src="options.js"></script>
+<script src="options.js" type="module"></script>
 </body>
 
 </html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,3 +1,5 @@
+import { DEFAULT_OPTIONS, CUSTOM_DUMMY_PASSWORD_KEY, LOGGING_ENABLED_KEY } from './options_defaults.js';
+
 function saveOptions() {
     var options = {};
     options[CUSTOM_DUMMY_PASSWORD_KEY] = document.querySelector('#dummyPassword').value;

--- a/src/options/options_defaults.js
+++ b/src/options/options_defaults.js
@@ -1,8 +1,9 @@
 // values are overridden by WebExtensions storage settings
-var DEFAULT_OPTIONS = {};
 
-var CUSTOM_DUMMY_PASSWORD_KEY = 'defaultDummyPassword';
-var LOGGING_ENABLED_KEY = 'loggingEnabled';
+export const CUSTOM_DUMMY_PASSWORD_KEY = 'defaultDummyPassword';
+export const LOGGING_ENABLED_KEY = 'loggingEnabled';
 
-DEFAULT_OPTIONS[CUSTOM_DUMMY_PASSWORD_KEY] = '0Pa$$4uM^t3';
-DEFAULT_OPTIONS[LOGGING_ENABLED_KEY] = false;
+export const DEFAULT_OPTIONS = {
+    [CUSTOM_DUMMY_PASSWORD_KEY]: '0Pa$$4uM^t3',
+    [LOGGING_ENABLED_KEY]: false,
+};


### PR DESCRIPTION
At the moment it does not support `{min,max,}length` attributes.

~~Depends on randexp, which uses `require` to load its dependencies so we need a bundler like Parcel but Parcel currently [does not support `executeScript`](https://github.com/parcel-bundler/parcel/issues/5758).~~ I switched to reregexp, which does not have any dependencies. Still requires some fiddling to be able to load CommonJS module.